### PR TITLE
Fixing broken link in API reference for set_light

### DIFF
--- a/adafruit_hue.py
+++ b/adafruit_hue.py
@@ -158,8 +158,7 @@ class Bridge:
         :param int hue: Hue value to set the light, in degrees (0 to 360) (0 to 65535)
         :param int sat: Saturation of the light, 0-100% (0 to 254)
         (more settings at:
-        https://developers.meethue.com/develop/
-        hue-api/lights-api/#set-light-state)
+        https://developers.meethue.com/develop/hue-api/lights-api/#set-light-state )
         """
         resp = self._put('{0}/lights/{1}/state'.format(self._username_url, light_id), kwargs)
         return resp


### PR DESCRIPTION
The line break in the docstring for the Bridge.set_light() method was causing a broken link in the generated documentation. The line break was removed to fix the link and a space after the link was added so the closing parenthesis was not included in the link.