### PR TITLE
Fixes Issue #15: build status badge is a broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Introduction
     :target: https://adafru.it/discord
     :alt: Discord
 
-.. image:: https://github.com/adafruit/Adafruit_CircuitPython_Hue/workflows/Build%CI/badge.svg
+.. image:: https://github.com/adafruit/Adafruit_CircuitPython_Hue/workflows/Build%20CI/badge.svg
     :target: https://github.com/adafruit/Adafruit_CircuitPython_Hue/actions/
     :alt: Build Status
 


### PR DESCRIPTION
## Description
There was a typo in the markdown where instead of ```%20``` for a space, only a ```%``` was being used. This resulted in the build status badge failing to show. This PR fixes that issue by fixing the typo in the markdown text.

Fixes Issue #15 