### PR TITLE
change requirements to pypi format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 Adafruit-Blinka
 Adafruit_CircuitPython_ESP32SPI
-Adafruit_CircuitPython_SimpleIO
+adafruit-circuitpython-simpleio


### PR DESCRIPTION
While pypi doesn't care about `-` versus `_` and letter case, the format used for the minimqtt requirement makes it listed in "external_dependencies" instead of "dependencies" in the bundle's json file, causing potential issues with bundler tools.
