### PR TITLE
Use more specific error for discovering bridge_wifi

### DIFF
--- a/adafruit_hue.py
+++ b/adafruit_hue.py
@@ -98,7 +98,7 @@ class Bridge:
             json_data = resp.json()
             bridge_ip = json_data[0]["internalipaddress"]
             resp.close()
-        except Exception as err:
+        except IndexError as err:
             raise TypeError(
                 "Ensure the Philips Bridge and CircuitPython device\
                              are both on the same WiFi network."


### PR DESCRIPTION
If the Hue isn't connected to the same network as the CircuitPython device, the payload is an empty list `[]`.  This updates the error handling to only catch that as the sign, and allow other errors to be raised so that other issues aren't mistakenly flagged as this.

Not tested, just checked the payload myself on my laptop to be sure.